### PR TITLE
Update doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ This plugin introduces displayed range search buffer.
 
 ```lua
 -- search in the current window
-vim.keymap.set({ "n", "x" }, "gs", [[<Cmd>lua require("reacher").start()<CR>]])
+vim.keymap.set({ "n", "x" }, "gs", [[<Cmd>lua require("reacher").start({})<CR>]])
 
 -- search in the all windows in the current tab
-vim.keymap.set({ "n", "x" }, "gS", [[<Cmd>lua require("reacher").start_multiple()<CR>]])
+vim.keymap.set({ "n", "x" }, "gS", [[<Cmd>lua require("reacher").start_multiple({})<CR>]])
 
 -- search in the current line
 vim.keymap.set({ "n", "x" }, "gl", function()

--- a/doc/reacher.nvim.txt
+++ b/doc/reacher.nvim.txt
@@ -62,10 +62,10 @@ EXAMPLES                                               *reacher.nvim-EXAMPLES*
 
 >lua
   -- search in the current window
-  vim.keymap.set({ "n", "x" }, "gs", [[<Cmd>lua require("reacher").start()<CR>]])
+  vim.keymap.set({ "n", "x" }, "gs", [[<Cmd>lua require("reacher").start({})<CR>]])
 
   -- search in the all windows in the current tab
-  vim.keymap.set({ "n", "x" }, "gS", [[<Cmd>lua require("reacher").start_multiple()<CR>]])
+  vim.keymap.set({ "n", "x" }, "gS", [[<Cmd>lua require("reacher").start_multiple({})<CR>]])
 
   -- search in the current line
   vim.keymap.set({ "n", "x" }, "gl", function()


### PR DESCRIPTION
The following code will result in a warning message by lsp(sumneko_lua): "This function requires 1 argument(s) but instead it is receiving 0.
``` lua
vim.keymap.set({ "n", "x" }, "gs", [[<Cmd>lua require("reacher").start()<CR>]]) 
vim.keymap.set({ "n", "x" }, "gS", [[<Cmd>lua require("reacher").start_multiple()<CR>]])

```